### PR TITLE
Recover BatchState after a Tomcat restart.

### DIFF
--- a/ingest-src/src/main/java/org/cdlib/mrt/ingest/BatchState.java
+++ b/ingest-src/src/main/java/org/cdlib/mrt/ingest/BatchState.java
@@ -98,6 +98,11 @@ public class BatchState
       try {
           return batchReadiness.get(id);
       } catch (Exception e) {
+	  // Recovering from a Tomcat restart
+	  if (! batchReadiness.containsKey(id)) {
+		System.out.println("Recovering from a Shutdown.  Forcing batch ready: " + id);
+		return 1;
+	  }
 	  return 0;
       }
     } 

--- a/ingest-src/src/main/java/org/cdlib/mrt/ingest/IngestManager.java
+++ b/ingest-src/src/main/java/org/cdlib/mrt/ingest/IngestManager.java
@@ -777,12 +777,15 @@ public class IngestManager {
 				// update batch object on disk (must be synchronous)
 				batchState = new BatchState(jobState.grabBatchID());
 
-				// Does not scale!!
-				// batchState = ProfileUtil.readFrom(batchState,
-				// ingestRequest.getQueuePath().getParentFile());
-
-				batchState = BatchState.getBatchState(jobState.grabBatchID().getValue());
-				batchState.setBatchID(jobState.grabBatchID());
+				try {
+				   batchState = BatchState.getBatchState(jobState.grabBatchID().getValue());
+				   batchState.setBatchID(jobState.grabBatchID());
+				} catch (Exception eee) {
+				   // Recover from restart
+				   System.out.println("[info]" + MESSAGE + "Batch not defined. Read from serialized object on disk: " + jobState.getJobID());
+				   batchState = ProfileUtil.readFrom(batchState, ingestRequest.getQueuePath().getParentFile());
+				   batchState.setBatchID(jobState.grabBatchID());
+				}
 
 				// remove old job and replace w/ new
 				Map<String, JobState> jobStates = (HashMap<String, JobState>) batchState.getJobStates();

--- a/ingest-src/src/main/java/org/cdlib/mrt/ingest/consumer/Consumer.java
+++ b/ingest-src/src/main/java/org/cdlib/mrt/ingest/consumer/Consumer.java
@@ -91,7 +91,7 @@ public class Consumer extends HttpServlet
 
     private String queueConnectionString = "localhost:2181";	// default single server connection
     private String queueNode = "/server.1";	// default queue
-    private String queuePath = "/dpr2/ingest_home";  // default
+    private String queuePath = null;
     private int numThreads = 5;		// default size
     private int pollingInterval = 2;	// default interval (minutes)
 

--- a/ingest-src/src/main/java/org/cdlib/mrt/ingest/consumer/Consumer.java
+++ b/ingest-src/src/main/java/org/cdlib/mrt/ingest/consumer/Consumer.java
@@ -91,6 +91,7 @@ public class Consumer extends HttpServlet
 
     private String queueConnectionString = "localhost:2181";	// default single server connection
     private String queueNode = "/server.1";	// default queue
+    private String queuePath = "/dpr2/ingest_home";  // default
     private int numThreads = 5;		// default size
     private int pollingInterval = 2;	// default interval (minutes)
 
@@ -132,6 +133,18 @@ public class Consumer extends HttpServlet
 	    System.err.println("[warn] " + MESSAGE + "Could not set queue node: " + queueNode +
 		 "  - using default: " + this.queueNode);
 	}
+
+	try {
+	    queuePath = ingestService.getIngestServiceProp() + "/queue/";
+	    if (StringUtil.isNotEmpty(queuePath)) {
+	    	System.out.println("[info] " + MESSAGE + "Setting queue path: " + queuePath);
+		this.queuePath = queuePath;
+	    }
+	} catch (Exception e) {
+	    System.err.println("[warn] " + MESSAGE + "Could not set queue path: " + queuePath +
+		 "  - using default: " + this.queuePath);
+	}
+
 
 	try {
 	    numThreads = ingestService.getQueueServiceConf().getString("NumThreads");
@@ -250,8 +263,8 @@ public class Consumer extends HttpServlet
             while(iterator.hasNext()){
                 BatchState batchState = BatchState.getBatchState((String) iterator.next());
                 System.out.println("[warning] " + MESSAGE + "Shutdown detected, writing to disk: " + batchState.getBatchID().getValue());
-                System.out.println("[warning] " + MESSAGE + "queue path: " + BatchState.getQueuePath(batchState.getBatchID().getValue()));
-                ProfileUtil.writeTo(batchState, new File(BatchState.getQueuePath(batchState.getBatchID().getValue())).getParentFile());
+                System.out.println("[warning] " + MESSAGE + "queue path: " + queuePath + "/" + batchState.getBatchID().getValue());
+                ProfileUtil.writeTo(batchState, new File(queuePath + "/" + batchState.getBatchID().getValue()));
             }
 	} catch (Exception e) {
 	    e.printStackTrace(System.err);


### PR DESCRIPTION
Use case includes sucessfully processing ZK pending jobs after a restart.